### PR TITLE
Add a Share button

### DIFF
--- a/main.tscn
+++ b/main.tscn
@@ -122,6 +122,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[connection signal="text_changed" from="HSplitContainer/VBoxContainer/ScriptEditor" to="HSplitContainer/VBoxContainer/ScriptEditor" method="_on_ScriptEditor_text_changed"]
 [connection signal="pressed" from="HSplitContainer/VBoxContainer/ScriptEditor/RunButton" to="HSplitContainer/VBoxContainer/ScriptEditor" method="_run_button_pressed"]
 [connection signal="pressed" from="HSplitContainer/VBoxContainer/ScriptEditor/ShareButton" to="HSplitContainer/VBoxContainer/ScriptEditor" method="_on_ShareButton_pressed"]
 [connection signal="timeout" from="HSplitContainer/VBoxContainer/ScriptEditor/CopiedTimer" to="HSplitContainer/VBoxContainer/ScriptEditor" method="_on_CopiedTimer_timeout"]

--- a/main.tscn
+++ b/main.tscn
@@ -18,9 +18,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 theme = ExtResource( 4 )
 script = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="HSplitContainer" type="HSplitContainer" parent="."]
 anchor_right = 1.0
@@ -71,9 +68,20 @@ grow_horizontal = 0
 hint_tooltip = "Shortcut: Ctrl + Enter"
 text = "Run"
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+
+[node name="ShareButton" type="Button" parent="HSplitContainer/VBoxContainer/ScriptEditor"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -196.0
+margin_top = 15.0
+margin_right = -111.0
+margin_bottom = 48.0
+grow_horizontal = 0
+hint_tooltip = "Shortcut: Ctrl + Enter"
+text = "Share"
+
+[node name="CopiedTimer" type="Timer" parent="HSplitContainer/VBoxContainer/ScriptEditor"]
+one_shot = true
 
 [node name="OutputPanel" type="PanelContainer" parent="HSplitContainer"]
 margin_left = 668.0
@@ -115,3 +123,5 @@ __meta__ = {
 }
 
 [connection signal="pressed" from="HSplitContainer/VBoxContainer/ScriptEditor/RunButton" to="HSplitContainer/VBoxContainer/ScriptEditor" method="_run_button_pressed"]
+[connection signal="pressed" from="HSplitContainer/VBoxContainer/ScriptEditor/ShareButton" to="HSplitContainer/VBoxContainer/ScriptEditor" method="_on_ShareButton_pressed"]
+[connection signal="timeout" from="HSplitContainer/VBoxContainer/ScriptEditor/CopiedTimer" to="HSplitContainer/VBoxContainer/ScriptEditor" method="_on_CopiedTimer_timeout"]

--- a/script_editor.gd
+++ b/script_editor.gd
@@ -141,6 +141,8 @@ func {name}(arg1 = '', arg2 = '', arg3 = '', arg4 = '', arg5 = '', arg6 = '', ar
 # The script shim that will be inserted at the end of the user-provided script.
 var script_shim := ""
 
+# JavaScript event callback for 'hashchange'
+var _on_hashchange_callback
 
 func _ready() -> void:
 	# Add in the missing bits of syntax highlighting for GDScript.
@@ -168,67 +170,13 @@ func _ready() -> void:
 				end_separator = "" if print_func == "printraw" else "\\n",
 		})
 	
+	# Load initial URL hash, if present
+	_try_load_url_hash_text()
 	
-	# Load query string, if present
-	var query_gd = get_query_source()
-	if query_gd != null:
-		text = query_gd
-
-func get_query_source():
-	var param = get_query_parameter("gd")
-	if param == null:
-		param = get_query_parameter("gdz")
-		if param == null:
-			return null
-		var base64 := base64url_to_base64(param)
-		var compressed := Marshalls.base64_to_raw(base64)
-		var uncompressed := compressed.decompress_dynamic(1024 * 1024, File.COMPRESSION_GZIP)
-		return uncompressed.get_string_from_utf8()
-	
-	var base64 := base64url_to_base64(param)
-	var uncompressed := Marshalls.base64_to_raw(base64)
-	return uncompressed.get_string_from_utf8()
-
-func set_query_source(source: String):
-	var uncompressed := source.to_utf8()
-	var compressed := uncompressed.compress(File.COMPRESSION_GZIP)
-	
-	if compressed.size() < uncompressed.size():
-		var base64 := Marshalls.raw_to_base64(compressed)
-		var base64url := base64_to_base64url(base64)
-		return set_query_parameter("gdz", base64url, "gd")
-	else:
-		var base64 := Marshalls.raw_to_base64(uncompressed)
-		var base64url := base64_to_base64url(base64)
-		return set_query_parameter("gd", base64url, "gdz")
-
-func base64url_to_base64(base64url: String) -> String:
-	return base64url.replace("-", "+").replace("_", "/").replace(".", "=")
-
-func base64_to_base64url(base64: String) -> String:
-	return base64.replace("+", "-").replace("/", "_").replace("=", ".")
-
-func get_query_parameter(parameter: String):
+	# Subscribe to URL hash changes
 	if OS.has_feature('JavaScript'):
-		return JavaScript.eval("""
-			let url = new URL(document.location);
-			url.searchParams.get("%s");
-		""" % [parameter])
-	return null
-
-func set_query_parameter(parameter: String, value: String, unsetParam := ""):
-	if OS.has_feature('JavaScript'):
-		return JavaScript.eval("""
-			let url = new URL(document.location);
-			url.searchParams.set("%s", "%s");
-			let unsetparam = "%s";
-			if (unsetparam !== "") {
-				url.searchParams.delete(unsetparam);
-			}
-			window.history.pushState({}, "", url);
-			url.toString();
-		""" % [parameter, value, unsetParam])
-	return null
+		_on_hashchange_callback = JavaScript.create_callback(self, "_on_hashchange")
+		JavaScript.get_interface("window").addEventListener("hashchange", _on_hashchange_callback)
 
 func _run_button_pressed() -> void:
 	# Clear the Output panel.
@@ -275,7 +223,7 @@ func _gui_input(event: InputEvent) -> void:
 
 
 func _on_ShareButton_pressed():
-	var newUrl = set_query_source(text)
+	var newUrl = _set_url_hash_source(text)
 	if newUrl != null:
 		OS.clipboard = newUrl
 		$ShareButton.text = "Copied!"
@@ -284,3 +232,75 @@ func _on_ShareButton_pressed():
 
 func _on_CopiedTimer_timeout():
 	$ShareButton.text = "Share"
+
+func _try_load_url_hash_text():
+	var query_gd = _get_url_hash_source()
+	if query_gd != null:
+		text = query_gd
+
+func _on_hashchange(_event):
+	print("Hash changed")
+	_try_load_url_hash_text()
+
+func _get_url_hash_source():
+	var param = _get_url_hash()
+	if param == null:
+		print("No hash to load")
+		return null
+	
+	print("Loading hash: #%s" % param)
+	
+	var base64 := _base64url_to_base64(param)
+	var raw := Marshalls.base64_to_raw(base64)
+	
+	if raw.size() > 2 && raw[0] == 0x1F && raw[1] == 0x8B:
+		raw = raw.decompress_dynamic(1024 * 1024, File.COMPRESSION_GZIP)
+	
+	return raw.get_string_from_utf8()
+
+func _set_url_hash_source(source: String):
+	var uncompressed := source.to_utf8()
+	var compressed := uncompressed.compress(File.COMPRESSION_GZIP)
+	var base64 = null
+	
+	if compressed.size() < uncompressed.size():
+		base64 = Marshalls.raw_to_base64(compressed)
+	else:
+		base64 = Marshalls.raw_to_base64(uncompressed)
+	
+	var base64url := _base64_to_base64url(base64)
+	return _set_url_hash(base64url)
+
+func _base64url_to_base64(base64url: String) -> String:
+	var base64 = base64url.replace("-", "+").replace("_", "/")
+	if base64.length() % 4 != 0:
+		base64 += "=".repeat(4 - base64.length() % 4)
+	return base64
+
+func _base64_to_base64url(base64: String) -> String:
+	return base64.replace("+", "-").replace("/", "_").rstrip("=")
+
+func _get_url_hash():
+	if OS.has_feature('JavaScript'):
+		var location = JavaScript.get_interface("location")
+		if location.hash != "":
+			return location.hash.substr(1)
+	return null
+
+func _set_url_hash(value: String):
+	if OS.has_feature('JavaScript'):
+		var location = JavaScript.get_interface("location")
+		print("Setting location.hash (\"%s\") = \"%s\"" % [location.hash, value])
+		if ((location.hash != "" && location.hash.substr(1) != value) ||
+			(location.hash == "" && value != "")):
+				var history = JavaScript.get_interface("history")
+				var url = JavaScript.create_object("URL", location)
+				url.hash = value
+				history.pushState(JavaScript.create_object("Object"), "", url)
+				print("Navigated to: %s" % url.toString())
+				return url.toString()
+	return null
+
+
+func _on_ScriptEditor_text_changed():
+	_set_url_hash("")


### PR DESCRIPTION
Adds a "Share" button next to the "Run" button.

When clicked, the current source code is compressed, converted to base64url (https://www.base64url.com/), appended to the current location as a hash/fragment, and the URL is copied to the clipboard.

A demonstration can be found here: https://gdscript-online.rareskelly.com/

![image](https://user-images.githubusercontent.com/2352020/215902264-200d386f-e30b-464f-93d1-a7bd6f263d09.png)

![image](https://user-images.githubusercontent.com/2352020/215902444-322c0248-726f-46b8-923f-30c71addc372.png)

Additional behavior:
- When any changes are made to the source, the URL fragment is cleared, to avoid confusion.
- The source in the URL fragment is loaded on page load, and also when the fragment is changed.
  - This is useful if the user pastes a new URL into an existing tab.
- The source code is gzipped unless the resulting gzipped size is larger than the original text. The decoder checks for gzip's magic bytes to know which format to load.

Additional notes:
- Large sizes can lag the browser for a bit, not sure if there's an easy fix.
- The URL fragment was chosen instead of query parameters because query parameters are sent to the server on request, fragments are not.
